### PR TITLE
Add a build-time environment variable to deploy Alerta Web at a sub-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,11 @@ at https://beta.alerta.io/alerta/, set `BASE_URL` to `/alerta`:
 
     $ export BASE_URL=/alerta
 
-The value can also be set to an empty string (`''`) or a relative path (`./`)
-so that all assets are linked using relative paths. This allows the built
-bundle to be deployed under any public path.
+The value cannot be set to an empty string (`''`) or a relative path (`./`)
+because Alerta Web is using HTML5 `history.pushState` routing that does not
+work properly with relative paths. See
+[Limitations of relative publicPath](https://cli.vuejs.org/config/#publicpath)
+for details.
 
 Deployment
 ----------

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ necessary for most deployments.
 
     $ export VUE_APP_CLIENT_ID=0ffe5d26-6c66-4871-a6fa-593d9fa972b1
 
+By default, Alerta Web assumes it will be deployed at the root of a
+domain, e.g. https://beta.alerta.io/. If Alerta Web is deployed at a
+sub-path, it will need to specify that sub-path using the `BASE_URL`
+build-time environment variable. For example, if Alerta Web is deployed
+at https://beta.alerta.io/alerta/, set `BASE_URL` to `/alerta`:
+
+    $ export BASE_URL=/alerta
+
+The value can also be set to an empty string (`''`) or a relative path (`./`)
+so that all assets are linked using relative paths. This allows the built
+bundle to be deployed under any public path.
+
 Deployment
 ----------
 

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  publicPath: '/',
+  publicPath: process.env.BASE_URL,
   devServer: {
     disableHostCheck: true
   }


### PR DESCRIPTION
Fixes https://github.com/alerta/alerta-webui/issues/149

This change allows using a build-time environment variable to build and deploy Alerta Web at a sub-path of a domain. So Alerta Web can be deployed at URL like `https://beta.alerta.io/alerta/`.

Using the environment variable is more convenient than changing the source code to prepare a custom build of Alerta Web.