### PR TITLE
Be smarter when working out when new alerts have arrived

### DIFF
--- a/src/components/AlertList.vue
+++ b/src/components/AlertList.vue
@@ -404,8 +404,8 @@
 
 <script>
 import debounce from 'lodash/debounce'
+import get from 'lodash/get'
 import DateTime from './lib/DateTime'
-import _ from 'lodash'
 import moment from 'moment'
 
 export default {
@@ -547,8 +547,8 @@ export default {
 
       // use default sort
       return items.sort((a, b) => {
-        const aValue = _.get(a, index)
-        const bValue = _.get(b, index)
+        const aValue = get(a, index)
+        const bValue = get(b, index)
         if (aValue === bValue) {
           return 0
         } else if (aValue == null) {

--- a/src/router.ts
+++ b/src/router.ts
@@ -184,7 +184,6 @@ export function createRouter(basePath): VueRouter {
   router.beforeEach((to, from, next) => {
     if (to.fullPath.substr(0, 2) === '/#') {
       const pathMinusHashbang = to.fullPath.substr(2)
-      console.log('rewriting ', to.fullPath, ' to ', pathMinusHashbang)
       next(pathMinusHashbang)
     } else {
       next()

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -2,8 +2,6 @@ import Vue from 'vue'
 import axios from 'axios'
 import { AxiosRequestConfig } from 'axios'
 
-const logRequests = !!process.env.VUE_APP_DEBUG
-
 const api = {
   get(url: string, config?: AxiosRequestConfig) {
     return this.request('GET', url, null, config)
@@ -35,10 +33,8 @@ const api = {
     data?: any,
     config?: AxiosRequestConfig
   ) {
-    logRequests && console.log(`${method} ${url}...`)
     let t0 = performance.now()
     return axios.request({ ...config, url, method, data }).then(response => {
-      logRequests && console.log(response)
       let t1 = performance.now()
       Vue.prototype.$track('timing_complete', {
         name: method,


### PR DESCRIPTION
Watching the entire alert list just to see if a new alert had arrived was leading to memory leaks and poor performance.

Also, don't load all of "lodash" just to just two helper functions a remove unnecessary console.log() statements.

Fixes #162 (hopefully)