### PR TITLE
Add user preference for initial default rowsPerPage for alert summary

### DIFF
--- a/src/components/AlertList.vue
+++ b/src/components/AlertList.vue
@@ -455,6 +455,9 @@ export default {
     timer: null
   }),
   computed: {
+    rowsPerPage() {
+      return this.$store.getters.getPreference('rowsPerPage')
+    },
     pagination: {
       get() {
         return this.$store.state.alerts.pagination
@@ -494,6 +497,11 @@ export default {
     },
     username() {
       return this.$store.getters['auth/getUsername']
+    }
+  },
+  watch: {
+    rowsPerPage(val) {
+      this.pagination = Object.assign({}, this.pagination, {rowsPerPage: val})
     }
   },
   methods: {

--- a/src/components/ApiKeyList.vue
+++ b/src/components/ApiKeyList.vue
@@ -319,7 +319,7 @@ export default {
   data: vm => ({
     descending: true,
     page: 1,
-    rowsPerPageItems: [10, 20, 30, 40],
+    rowsPerPageItems: [10, 20, 30, 40, 50],
     pagination: {
       sortBy: 'lastUsedTime',
       rowsPerPage: 20

--- a/src/components/BlackoutList.vue
+++ b/src/components/BlackoutList.vue
@@ -406,7 +406,7 @@ export default {
   data: vm => ({
     descending: true,
     page: 1,
-    rowsPerPageItems: [10, 20, 30, 40],
+    rowsPerPageItems: [10, 20, 30, 40, 50],
     pagination: {
       sortBy: 'startTime',
       rowsPerPage: 20

--- a/src/components/CustomerList.vue
+++ b/src/components/CustomerList.vue
@@ -171,7 +171,7 @@ export default {
   data: () => ({
     descending: true,
     page: 1,
-    rowsPerPageItems: [10, 20, 30, 40],
+    rowsPerPageItems: [10, 20, 30, 40, 50],
     pagination: {
       sortBy: 'match',
       rowsPerPage: 20

--- a/src/components/GroupList.vue
+++ b/src/components/GroupList.vue
@@ -290,7 +290,7 @@ export default {
   data: vm => ({
     descending: true,
     page: 1,
-    rowsPerPageItems: [10, 20, 30, 40],
+    rowsPerPageItems: [10, 20, 30, 40, 50],
     pagination: {
       sortBy: 'name',
       rowsPerPage: 20

--- a/src/components/HeartbeatList.vue
+++ b/src/components/HeartbeatList.vue
@@ -114,7 +114,7 @@ export default {
   data: () => ({
     descending: true,
     page: 1,
-    rowsPerPageItems: [10, 20, 30, 40],
+    rowsPerPageItems: [10, 20, 30, 40, 50],
     pagination: {
       sortBy: 'receiveTime',
       descending: true,

--- a/src/components/PermList.vue
+++ b/src/components/PermList.vue
@@ -240,7 +240,7 @@ export default {
   data: () => ({
     descending: true,
     page: 1,
-    rowsPerPageItems: [10, 20, 30, 40],
+    rowsPerPageItems: [10, 20, 30, 40, 50],
     pagination: {
       sortBy: 'match',
       rowsPerPage: 20

--- a/src/components/Preferences.vue
+++ b/src/components/Preferences.vue
@@ -94,6 +94,14 @@
         <v-card-actions>
           <v-layout column>
             <v-combobox
+              v-model.number="rowsPerPage"
+              :items="rowsPerPageItems"
+              label="Rows per page"
+              type="number"
+              suffix="rows"
+            />
+
+            <v-combobox
               v-model.number="refreshInterval"
               :items="refreshOptions"
               label="Refresh interval"
@@ -206,6 +214,17 @@ export default {
         this.$store.dispatch('setUserPrefs', {
           dates: {shortTime: value}
         })
+      }
+    },
+    rowsPerPageItems() {
+      return this.$store.state.alerts.pagination.rowsPerPageItems
+    },
+    rowsPerPage: {
+      get() {
+        return (this.$store.getters.getPreference('rowsPerPage') || this.$store.state.alerts.pagination.rowsPerPage)
+      },
+      set(value) {
+        this.$store.dispatch('setUserPrefs', {rowsPerPage: value})
       }
     },
     refreshInterval: {

--- a/src/components/UserList.vue
+++ b/src/components/UserList.vue
@@ -412,7 +412,7 @@ export default {
   data: vm => ({
     descending: true,
     page: 1,
-    rowsPerPageItems: [10, 20, 30, 40],
+    rowsPerPageItems: [10, 20, 30, 40, 50],
     pagination: {
       sortBy: 'name',
       rowsPerPage: 20

--- a/src/store/modules/alerts.store.ts
+++ b/src/store/modules/alerts.store.ts
@@ -53,7 +53,7 @@ const state = {
     rowsPerPage: 20,
     sortBy: 'default',
     totalItems: 0,
-    rowsPerPageItems: [10, 20, 30, 40]
+    rowsPerPageItems: [10, 20, 30, 40, 50]
   }
 }
 

--- a/src/store/modules/preferences.store.ts
+++ b/src/store/modules/preferences.store.ts
@@ -11,6 +11,7 @@ const getDefaults = () => {
       mediumDate: 'ddd D MMM HH:mm',
       shortTime: 'LT'
     },
+    rowsPerPage: 20,
     refreshInterval: 5*1000,
     shelveTimeout: 2*60*60
   }


### PR DESCRIPTION
And add an extra option of viewing 50 rows at a time for all lists. (as per GMail)