### PR TITLE
Do not wrap any alarm summary columns

### DIFF
--- a/src/components/AlertList.vue
+++ b/src/components/AlertList.vue
@@ -62,6 +62,7 @@
           <td
             v-for="col in $config.columns"
             :key="col"
+            class="text-no-wrap"
           >
             <span
               v-if="col == 'id'"
@@ -219,6 +220,7 @@
           </td>
           <td
             :colspan="(showIcons === props.item.id && !selectableRows) ? '1' : '2'"
+            class="text-no-wrap"
           >
             <div class="fixed-table">
               <div class="text-truncate">


### PR DESCRIPTION
Before ...
<img width="1360" alt="Screenshot 2019-05-31 at 23 51 43" src="https://user-images.githubusercontent.com/615057/58736720-29a3a380-83ff-11e9-830a-f4545a94fcf8.png">
After ...
<img width="1361" alt="Screenshot 2019-05-31 at 23 52 01" src="https://user-images.githubusercontent.com/615057/58736714-26a8b300-83ff-11e9-8956-19b1cbf298a2.png">

Fixes #182 