### PR TITLE
Add option to display times in local or UTC

### DIFF
--- a/src/components/Preferences.vue
+++ b/src/components/Preferences.vue
@@ -69,6 +69,12 @@
               :items="timeFormats"
               label="Short time format"
             />
+
+            <v-select
+              v-model="timezone"
+              :items="timezoneOptions"
+              label="Display mode"
+            />
           </v-layout>
         </v-card-actions>
       </v-flex>
@@ -166,6 +172,10 @@ export default {
       {text: moment().format('HH:mm:ss'), value: 'HH:mm:ss'},
       {text: moment().format('HH:mm:ss.SSS Z'), value: 'HH:mm:ss.SSS Z'},
     ],
+    timezoneOptions: [
+      {text: 'Use local date & time', value: 'local'},
+      {text: 'Use Coordinated Universal Time (UTC)', value: 'utc'}
+    ],
     refreshOptions: [2, 5, 10, 30, 60],  // seconds
     shelveTimeoutOptions: [1, 2, 4, 8, 24]  // hours
   }),
@@ -213,6 +223,16 @@ export default {
       set(value) {
         this.$store.dispatch('setUserPrefs', {
           dates: {shortTime: value}
+        })
+      }
+    },
+    timezone: {
+      get() {
+        return this.$store.state.prefs.timezone
+      },
+      set(value) {
+        this.$store.dispatch('setUserPrefs', {
+          timezone: value
         })
       }
     },

--- a/src/components/lib/DateTime.vue
+++ b/src/components/lib/DateTime.vue
@@ -4,9 +4,9 @@
       slot="activator"
       class="text-no-wrap"
     >
-      {{ value | date(formatString) }}
+      {{ value | date(displayMode, formatString) }}
     </span>
-    <span>{{ value | date('YYYY/MM/DD HH:mm:ss.SSS Z') }}</span>
+    <span>{{ value | date('utc', 'YYYY/MM/DD HH:mm:ss.SSS Z') }}</span>
   </v-tooltip>
 </template>
 
@@ -17,6 +17,9 @@ export default {
     format: { type: String, default: 'mediumDate' }
   },
   computed: {
+    displayMode() {
+      return this.$store.state.prefs.timezone
+    },
     formatString() {
       return (
         this.$store.state.prefs.dates[this.format] ||

--- a/src/filters/date.ts
+++ b/src/filters/date.ts
@@ -1,11 +1,17 @@
 import moment from 'moment'
 import Vue from 'vue'
 
-export default Vue.filter('date', function(value, format = 'll') {
+export default Vue.filter('date', function(value, mode='local', format = 'll') {
   if (value) {
-    return moment
-      .utc(String(value))
-      .local()
-      .format(format)
+    if (mode === 'utc') {
+      return moment
+        .utc(String(value))
+        .format(format)
+    } else {
+      return moment
+        .utc(String(value))
+        .local()
+        .format(format)
+    }
   }
 })

--- a/src/store/modules/preferences.store.ts
+++ b/src/store/modules/preferences.store.ts
@@ -11,6 +11,7 @@ const getDefaults = () => {
       mediumDate: 'ddd D MMM HH:mm',
       shortTime: 'LT'
     },
+    timezone: 'local',  // 'local' or 'utc'
     rowsPerPage: 20,
     refreshInterval: 5*1000,  // milliseconds
     shelveTimeout: 2*60*60  // seconds


### PR DESCRIPTION
<img width="440" alt="Screenshot 2019-06-20 at 22 57 17" src="https://user-images.githubusercontent.com/615057/59881012-cd54f380-93ae-11e9-9fbd-02ae13761f2a.png">

>what is the easiest way to set the default timezone in the alerta UI ? or is that even possible ? our team is globally distributed and using local time is not possibles and we need to set everything to UTC by default . it could be great if it can be switched from the UI itself . thanks in advance

/cc @sherif84 