### PR TITLE
Add display density options 'comfortable' and 'compact'

### DIFF
--- a/src/components/AlertList.vue
+++ b/src/components/AlertList.vue
@@ -7,6 +7,7 @@
       :pagination.sync="pagination"
       :rows-per-page-items="pagination.rowsPerPageItems"
       class="alert-table"
+      :class="[ displayDensity ]"
       :search="search"
       must-sort
       :custom-sort="customSort"
@@ -239,7 +240,7 @@
                 flat
                 icon
                 small
-                class="btn--plain px-1 mx-0"
+                class="btn--plain pa-0 ma-0"
                 @click.stop="takeAction(props.item.id, 'open')"
               >
                 <v-icon
@@ -254,7 +255,7 @@
                 flat
                 icon
                 small
-                class="btn--plain px-1 mx-0"
+                class="btn--plain pa-0 ma-0"
                 @click.stop="watchAlert(props.item.id)"
               >
                 <v-icon
@@ -268,7 +269,7 @@
                 flat
                 icon
                 small
-                class="btn--plain px-1 mx-0"
+                class="btn--plain pa-0 ma-0"
                 @click.stop="unwatchAlert(props.item.id)"
               >
                 <v-icon
@@ -283,7 +284,7 @@
                 flat
                 icon
                 small
-                class="btn--plain px-1 mx-0"
+                class="btn--plain pa-0 ma-0"
                 @click.stop="takeAction(props.item.id, 'ack')"
               >
                 <v-icon
@@ -297,7 +298,7 @@
                 flat
                 icon
                 small
-                class="btn--plain px-1 mx-0"
+                class="btn--plain pa-0 ma-0"
                 @click.stop="takeAction(props.item.id, 'unack')"
               >
                 <v-icon
@@ -312,7 +313,7 @@
                 flat
                 icon
                 small
-                class="btn--plain px-1 mx-0"
+                class="btn--plain pa-0 ma-0"
                 @click.stop="shelveAlert(props.item.id)"
               >
                 <v-icon
@@ -326,7 +327,7 @@
                 flat
                 icon
                 small
-                class="btn--plain px-1 mx-0"
+                class="btn--plain pa-0 ma-0"
                 @click.stop="takeAction(props.item.id, 'unshelve')"
               >
                 <v-icon
@@ -341,7 +342,7 @@
                 flat
                 icon
                 small
-                class="btn--plain px-1 mx-0"
+                class="btn--plain pa-0 ma-0"
                 @click.stop="takeAction(props.item.id, 'close')"
               >
                 <v-icon
@@ -354,7 +355,7 @@
                 flat
                 icon
                 small
-                class="btn--plain px-1 mx-0"
+                class="btn--plain pa-0 ma-0"
                 @click.stop="deleteAlert(props.item.id)"
               >
                 <v-icon
@@ -373,7 +374,7 @@
                   flat
                   icon
                   small
-                  class="btn--plain px-1 mx-0"
+                  class="btn--plain pa-0 ma-0"
                 >
                   <v-icon small>
                     more_vert
@@ -455,6 +456,9 @@ export default {
     timer: null
   }),
   computed: {
+    displayDensity() {
+      return this.$store.getters.getPreference('displayDensity')
+    },
     rowsPerPage() {
       return this.$store.getters.getPreference('rowsPerPage')
     },
@@ -479,7 +483,9 @@ export default {
       return headers
     },
     textColor() {
-      return `${this.$store.getters.getConfig('colors').text}--text`
+      return this.$store.getters.getConfig('colors').text
+        ? `${this.$store.getters.getConfig('colors').text}--text`
+        : ''
     },
     selectedItem() {
       return this.alerts.filter(a => a.id == this.selectedId)[0]
@@ -632,11 +638,25 @@ export default {
   padding: 0px 5px !important;
 }
 
+.comfortable table.v-table tbody td, table.v-table tbody th {
+  height: 42px !important;
+}
+
+.comfortable .v-table tbody td {
+  font-size: 14px !important;
+}
+
+.compact table.v-table tbody td, table.v-table tbody th {
+  height: 34px !important;
+}
+
+.compact .v-table tbody td {
+  font-size: 13px !important;
+}
+
 .alert-table .v-table tbody td {
   border-top: 1px solid rgb(221, 221, 221);
-  height: 42px;
   font-family: 'Sintony', sans-serif;
-  font-size: 14px;
 }
 
 .fixed-table {

--- a/src/components/AlertListFilter.vue
+++ b/src/components/AlertListFilter.vue
@@ -192,7 +192,7 @@
               max-width="290px"
               min-width="290px"
             >
-              <div slot="activator"/>
+              <div slot="activator" />
               <v-date-picker
                 v-model="period.startDate"
                 no-title
@@ -242,7 +242,7 @@
               max-width="290px"
               min-width="290px"
             >
-              <div slot="activator"/>
+              <div slot="activator" />
               <v-date-picker
                 v-model="period.endDate"
                 no-title

--- a/src/store/modules/preferences.store.ts
+++ b/src/store/modules/preferences.store.ts
@@ -12,6 +12,7 @@ const getDefaults = () => {
       shortTime: 'LT'
     },
     timezone: 'local',  // 'local' or 'utc'
+    displayDensity: 'comfortable',  // 'comfortable' or 'compact'
     rowsPerPage: 20,
     refreshInterval: 5*1000,  // milliseconds
     shelveTimeout: 2*60*60  // seconds

--- a/src/views/Alerts.vue
+++ b/src/views/Alerts.vue
@@ -5,6 +5,47 @@
       :src="audioURL"
     />
 
+    <v-dialog
+      v-model="densityDialog"
+      max-width="340px"
+    >
+      <v-form ref="form">
+        <v-card>
+          <v-card-title class="justify-center">
+            <span class="title">
+              Choose a display density
+            </span>
+          </v-card-title>
+          <v-card-actions class="justify-center">
+            <v-btn
+              value="comfortable"
+              :class="{ primary: displayDensity == 'comfortable' }"
+              @click="displayDensity = 'comfortable'"
+            >
+              Comfortable
+            </v-btn>
+            <v-btn
+              value="compact"
+              :class="{ primary: displayDensity == 'compact' }"
+              @click="displayDensity = 'compact'"
+            >
+              Compact
+            </v-btn>
+          </v-card-actions>
+          <v-card-actions>
+            <v-spacer />
+            <v-btn
+              color="blue darken-1"
+              flat
+              @click="ok"
+            >
+              OK
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-form>
+    </v-dialog>
+
     <v-expand-transition>
       <div
         v-if="showPanel"
@@ -29,14 +70,14 @@
     </v-expand-transition>
 
     <alert-detail
-      v-show="dialog"
+      v-show="detailDialog"
       v-if="selectedId"
       :id="selectedId"
       @close="close"
     />
 
     <v-tabs
-      v-if="!dialog"
+      v-if="!detailDialog"
       v-model="currentTab"
       class="px-1"
       grow
@@ -85,8 +126,13 @@
             @click="showPanel = !showPanel"
           >
             <v-list-tile-title>
-              {{ showPanel ? 'Hide' : 'Show' }} Panel
+              {{ showPanel ? 'Hide' : 'Show' }} panel
             </v-list-tile-title>
+          </v-list-tile>
+          <v-list-tile
+            @click="densityDialog = true"
+          >
+            Display density
           </v-list-tile>
         </v-list>
       </v-menu>
@@ -154,7 +200,8 @@ export default {
   },
   data: vm => ({
     currentTab: null,
-    dialog: false,
+    densityDialog: false,
+    detailDialog: false,
     selectedId: null,
     selectedItem: {},
     sidesheet: false,
@@ -236,12 +283,20 @@ export default {
         this.$store.dispatch('alerts/toggle', ['showPanel', value])
       }
     },
+    displayDensity: {
+      get() {
+        return this.$store.getters.getPreference('displayDensity')
+      },
+      set(value) {
+        this.$store.dispatch('setUserPrefs', {displayDensity: value})
+      }
+    },
     pagination() {
       return this.$store.state.alerts.pagination
     }
   },
   watch: {
-    dialog(val) {
+    detailDialog(val) {
       val || this.close()
     },
     filter: {
@@ -325,7 +380,7 @@ export default {
       this.selectedId = item.id
       this.selectedItem = Object.assign({}, item)
       this.$router.push({ path: `/alert/${item.id}` })
-      this.dialog = true
+      this.detailDialog = true
     },
     refreshAlerts() {
       this.getEnvironments()
@@ -341,8 +396,11 @@ export default {
         this.timer = null
       }
     },
+    ok() {
+      this.densityDialog = false
+    },
     close() {
-      this.dialog = false
+      this.detailDialog = false
       setTimeout(() => {
         this.selectedItem = {}
         this.selectedId = null


### PR DESCRIPTION
Comfortable display density ...

<img width="1194" alt="Screenshot 2019-07-05 at 22 20 14" src="https://user-images.githubusercontent.com/615057/60744013-41c59000-9f74-11e9-8fc6-e436377f2232.png">

Compact display density

<img width="1194" alt="Screenshot 2019-07-05 at 22 20 01" src="https://user-images.githubusercontent.com/615057/60744007-3d00dc00-9f74-11e9-931c-a634279e1f41.png">

**Note: The compact display density is the same display density used for the previous version of the Alerta Web UI (v6).**

Toggle display density using vertical menu on the alert list.

<img width="171" alt="Screenshot 2019-07-05 at 22 27 53" src="https://user-images.githubusercontent.com/615057/60743992-2fe3ed00-9f74-11e9-80b2-6c8c086d49ce.png">

<img width="272" alt="Screenshot 2019-07-05 at 22 27 30" src="https://user-images.githubusercontent.com/615057/60743997-32464700-9f74-11e9-8687-ad5136219579.png">
