### PR TITLE
Prevent icons from flickering on hover

### DIFF
--- a/src/components/AlertList.vue
+++ b/src/components/AlertList.vue
@@ -21,8 +21,8 @@
         <tr
           :style="{ 'background-color': severityColor(props.item.severity) }"
           class="hover-lighten"
-          @mouseover="showIcons = props.item.id"
-          @mouseout="showIcons = null"
+          @mouseenter="showIcons = props.item.id"
+          @mouseleave="showIcons = null"
           @click="selectItem(props.item)"
         >
           <td


### PR DESCRIPTION
>Though similar to mouseover, mouseenter differs in that it doesn't bubble and it isn't sent to any descendants when the pointer is moved from one of its descendants' physical space to its own physical space.

See https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseenter_event#Usage_notes