### PR TITLE
Add last note added column to alert list

### DIFF
--- a/src/components/AlertList.vue
+++ b/src/components/AlertList.vue
@@ -215,7 +215,12 @@
                 format="mediumDate"
               />
             </span>
-            <!-- history not supported -->
+            <!-- only history supported is most recent note -->
+            <span
+              v-if="col == 'note'"
+            >
+              {{ lastNote(props.item) }}
+            </span>
           </td>
           <td
             :colspan="(showIcons === props.item.id && !selectableRows) ? '1' : '2'"
@@ -448,6 +453,7 @@ export default {
       receiveTime: { text: 'Receive Time', value: 'receiveTime' },
       lastReceiveId: { text: 'Last Receive Id', value: 'lastReceiveId' },
       lastReceiveTime: { text: 'Last Receive Time', value: 'lastReceiveTime' },
+      note: { text: 'Last Note', value: 'note', sortable: false }
     },
     details: false,
     selectedId: null,
@@ -518,6 +524,10 @@ export default {
       let lastModified = this.isShelved(item.status) && item.updateTime ? item.updateTime : item.lastReceiveTime
       let expireTime = moment(lastModified).add(item.timeout, 'seconds')
       return expireTime.isAfter() ? expireTime.diff(moment(), 'seconds') : moment.duration()
+    },
+    lastNote(item) {
+      const note = item.history.filter(h => h.type == 'note').pop()
+      return note ? note.text : ''
     },
     customSort(items, index, isDescending) {
       if (!index) return items


### PR DESCRIPTION
<img width="1145" alt="Screenshot 2019-07-28 at 21 53 49" src="https://user-images.githubusercontent.com/615057/62012121-4996df80-b182-11e9-99f6-48a0bbb4ab98.png">

**Example server config**
```
COLUMNS = [
    'severity', 'status', 'lastReceiveTime', 'timeoutLeft', 'duplicateCount',
    'customer', 'environment', 'service', 'resource', 'event', 'value', 'note'
]
```

Fixes #219