### PR TITLE
Make last note more prominent on alert details page

### DIFF
--- a/src/components/AlertDetail.vue
+++ b/src/components/AlertDetail.vue
@@ -222,6 +222,13 @@
             <v-card
               flat
             >
+              <v-alert
+                :value="lastNote(item)"
+                type="info"
+                class="ma-1"
+              >
+                <b>Last Note</b> {{ lastNote(item) }}
+              </v-alert>
               <v-card-text>
                 <div class="flex xs12 ma-1">
                   <div class="d-flex align-top">
@@ -561,20 +568,6 @@
                     <div class="flex xs6 text-xs-left">
                       <div>
                         {{ item.origin }}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div class="flex xs12 ma-1">
-                  <div class="d-flex align-top">
-                    <div class="flex xs3 text-xs-left">
-                      <div class="grey--text">
-                        Last Note
-                      </div>
-                    </div>
-                    <div class="flex xs6 text-xs-left">
-                      <div>
-                        {{ lastNote(item) }}
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
<img width="1135" alt="Screenshot 2019-07-29 at 21 00 03" src="https://user-images.githubusercontent.com/615057/62074997-3fd5b080-b244-11e9-9120-af1fd0a39660.png">

/cc @strangeman 