### PR TITLE
Add alert ack reason card on details page

### DIFF
--- a/src/components/AlertDetail.vue
+++ b/src/components/AlertDetail.vue
@@ -231,6 +231,14 @@
                 <b>Last Note</b> by <b>{{ lastNote.user || 'Anonymous' }}</b> ({{ lastNote.updateTime | timeago }})<br>
                 {{ lastNote.text }}
               </v-alert>
+              <v-alert
+                v-show="isAcked(item.status)"
+                :value="ackReason(item)"
+                type="info"
+                class="ma-1"
+              >
+                <b>Ack reason</b> {{ ackReason(item) }}
+              </v-alert>
               <v-card-text>
                 <div class="flex xs12 ma-1">
                   <div class="d-flex align-top">
@@ -807,6 +815,10 @@ export default {
     this.getAlert(this.id)
   },
   methods: {
+    ackReason(item) {
+      const reason = item.history.filter(h => h.type == 'ack').pop()
+      return reason ? reason.text : ''
+    },
     getAlert() {
       this.$store.dispatch('alerts/getAlert', this.id)
     },


### PR DESCRIPTION
Logic is similar for the note card: if operator ack'ing alert, another operator should be able to see ack reason on the alert page.

 
![2019-08-01-121712_1892x659_scrot](https://user-images.githubusercontent.com/1083576/62261528-fc07c480-b458-11e9-8c58-947e0b7ead2b.png)
![2019-08-01-121746_1874x597_scrot](https://user-images.githubusercontent.com/1083576/62261529-fca05b00-b458-11e9-89e9-337ebac6d377.png)

