### PR TITLE
Allow server to override default alert list filter

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ bootstrap.getConfig()
 
     Vue.prototype.$config = config
     store.dispatch('updateConfig', config)
+    store.dispatch('alerts/setFilter', config.filter)
     store.registerModule('auth', makeStore(vueAuth(config)))
     axios.defaults.baseURL = config.endpoint
 

--- a/src/store/modules/alerts.store.ts
+++ b/src/store/modules/alerts.store.ts
@@ -5,16 +5,6 @@ import utils from '@/common/utils'
 
 const namespaced = true
 
-const getDefaultFilter = () => {
-  return {
-    text: null,
-    environment: null,
-    status: ['open', 'ack'],  // FIXME
-    service: null,
-    group: null,
-    dateRange: [null, null]
-  }
-}
 const state = {
   isLoading: false,
 
@@ -38,10 +28,10 @@ const state = {
 
   // query, filter and pagination
   query: {}, // URLSearchParams
-  filter: {
+  filter: {  // local defaults
     environment: null,
     text: null,
-    status: ['open', 'ack'],  // FIXME
+    status: ['open', 'ack'],
     customer: null,
     service: null,
     group: null,
@@ -107,9 +97,6 @@ const mutations = {
   },
   SET_FILTER(state, filter): any {
     state.filter = Object.assign({}, state.filter, filter)
-  },
-  RESET_FILTER(state): any {
-    state.filter = Object.assign({}, state.filter, getDefaultFilter())
   },
   SET_PAGINATION(state, pagination) {
     state.pagination = Object.assign({}, state.pagination, pagination)
@@ -255,8 +242,8 @@ const actions = {
   setFilter({ commit }, filter) {
     commit('SET_FILTER', filter)
   },
-  resetFilter({ commit }) {
-    commit('RESET_FILTER')
+  resetFilter({ commit, rootState }) {
+    commit('SET_FILTER', rootState.config.filter)
   },
   setPagination({ commit }, pagination) {
     commit('SET_PAGINATION', pagination)

--- a/src/store/modules/config.store.ts
+++ b/src/store/modules/config.store.ts
@@ -31,6 +31,14 @@ const state = {
   columns: [],
   sort_by: 'lastReceiveTime',
   actions: [],
+  filter: {
+    text: null,
+    environment: null,
+    status: null,
+    service: null,
+    group: null,
+    dateRange: [null, null]
+  },
 
   tracking_id: null,
   refresh_interval: 5*1000  // milliseconds


### PR DESCRIPTION
If the API server `/config` response includes a `filter {}` object that will be used as the default for alert list filter.

*Default*
```
DEFAULT_FILTER = {'status': ['open', 'ack']}
```

*Example*
```
DEFAULT_FILTER = {'environment': 'Production', 'status': ['open'], 'service': ['Web']}
```

> Anybody know if it is possible to change the default filters in the web UI? E.g., normally it defaults to "open" and "ack", curious if it's possible to change this behavior
> having trouble finding where in the code the default selections are
> 
> I would like by default for it to be [open] instead of [open, ack]
> In other words, I don't want my users to see a bunch of ACK'd alerts when the open the page
> unless they specifically are looking for them
> 

/cc @jonhammer 