### PR TITLE
Fixes high cpu load and blocking browser during multi actions

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -698,7 +698,7 @@ export default {
       })
     },
     bulkShelveAlert() {
-      Promise.All(this.selected.map(a => {
+      Promise.all(this.selected.map(a => {
         this.$store
           .dispatch('alerts/takeAction', [
             a.id,
@@ -723,7 +723,7 @@ export default {
         map = this.selected.map(a => this.unwatchAlert(a.id))
       }
     
-      Promise.All(map).then(() => {
+      Promise.all(map).then(() => {
         this.clearSelected()
         this.$store.dispatch('alerts/getAlerts')
       })

--- a/src/components/AlertList.vue
+++ b/src/components/AlertList.vue
@@ -609,7 +609,9 @@ export default {
     },
     takeAction: debounce(function(id, action) {
       this.$store
-        .dispatch('alerts/takeAction', [id, action, ''])
+        .dispatch('alerts/takeAction', [id, action, '']).then(() => {
+          this.$store.dispatch('alerts/getAlerts')
+        })
     }, 200, {leading: true, trailing: false}),
     shelveAlert: debounce(function(id) {
       this.$store
@@ -622,15 +624,21 @@ export default {
     }, 200, {leading: true, trailing: false}),
     watchAlert: debounce(function(id) {
       this.$store
-        .dispatch('alerts/watchAlert', id)
+        .dispatch('alerts/watchAlert', id).then(() => {
+          this.$store.dispatch('alerts/getAlerts')
+        })
     }, 200, {leading: true, trailing: false}),
     unwatchAlert: debounce(function(id) {
       this.$store
-        .dispatch('alerts/unwatchAlert', id)
+        .dispatch('alerts/unwatchAlert', id).then(() => {
+          this.$store.dispatch('alerts/getAlerts')
+        })
     }, 200, {leading: true, trailing: false}),
     deleteAlert: debounce(function(id) {
       confirm(i18n.t('ConfirmDelete')) &&
-        this.$store.dispatch('alerts/deleteAlert', id)
+        this.$store.dispatch('alerts/deleteAlert', id).then(() => {
+          this.$store.dispatch('alerts/getAlerts')
+        })
     }, 200, {leading: true, trailing: false}),
   }
 }

--- a/src/store/modules/alerts.store.ts
+++ b/src/store/modules/alerts.store.ts
@@ -170,33 +170,25 @@ const actions = {
   watchAlert({ commit, dispatch, rootState}, alertId) {
     const username = rootState.auth.payload.preferred_username
     const tag = `watch:${username}`
-    return AlertsApi.tagAlert(alertId, {tags: [tag]}).then(response =>
-      dispatch('getAlerts')
-    )
+    return AlertsApi.tagAlert(alertId, {tags: [tag]})
   },
   unwatchAlert({ commit, dispatch, rootState}, alertId) {
     const username = rootState.auth.payload.preferred_username
     const tag = `watch:${username}`
-    return AlertsApi.untagAlert(alertId, {tags: [tag]}).then(response =>
-      dispatch('getAlerts')
-    )
+    return AlertsApi.untagAlert(alertId, {tags: [tag]})
   },
   takeAction({ commit, dispatch }, [alertId, action, text, timeout]) {
     return AlertsApi.actionAlert(alertId, {
       action: action,
       text: text,
       timeout: timeout
-    }).then(response => dispatch('getAlerts'))
+    })
   },
   tagAlert({ commit, dispatch }, [alertId, tags]) {
-    return AlertsApi.tagAlert(alertId, tags).then(response =>
-      dispatch('getAlerts')
-    )
+    return AlertsApi.tagAlert(alertId, tags)
   },
   untagAlert({ commit, dispatch }, [alertId, tags]) {
-    return AlertsApi.untagAlert(alertId, tags).then(response =>
-      dispatch('getAlerts')
-    )
+    return AlertsApi.untagAlert(alertId, tags)
   },
   addNote({ commit, dispatch }, [alertId, note]) {
     return AlertsApi.addNote(alertId, {
@@ -204,9 +196,7 @@ const actions = {
     }).then(response => dispatch('getAlerts'))
   },
   deleteAlert({ commit, dispatch }, alertId) {
-    return AlertsApi.deleteAlert(alertId).then(response =>
-      dispatch('getAlerts')
-    )
+    return AlertsApi.deleteAlert(alertId)
   },
 
   getEnvironments({ commit }) {


### PR DESCRIPTION
### Current situation
Actions triggered for multiple selected alerts block the browser and lead to high cpu usage.
This can be triggered like:

1. Select 50 rows
2. Create 50 alerts
3. Select all alerts => hit delete

A DELETE request is sent for each resource which is fine. But for every request a reload of the whole list is made which also results in 50 fetch requests with the example above.
This may take several seconds and the browser is blocked.

### Should
Execute multi resource actions async but wait for the whole group and trigger a refresh in the end so that we only have one GET request to reload the list.

This pr removed the reload for actions and applies the reload to the calling functions while multi resource actions may only reload the list once.

Note: I only did some quick tests but it looks fine.

This pr may also lead to a possible increase of the 50 records limit. Currently it is quite painful to remove 200 alerts or more.
