### PR TITLE
Add support for ack timeouts

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -297,7 +297,7 @@
             slot="activator"
             icon
             class="btn--plain"
-            @click="takeBulkAction('ack')"
+            @click="bulkAckAlert()"
           >
             <v-icon>
               check
@@ -645,6 +645,9 @@ export default {
     selected() {
       return this.$store.state.alerts.selected
     },
+    ackTimeout() {
+      return this.$store.getters.getPreference('ackTimeout')
+    },
     shelveTimeout() {
       return this.$store.getters.getPreference('shelveTimeout')
     },
@@ -693,6 +696,18 @@ export default {
     },
     takeBulkAction(action) {
       this.selected.map(a => this.$store.dispatch('alerts/takeAction', [a.id, action, '']))
+        .reduce(() => this.clearSelected())
+    },
+    bulkAckAlert() {
+      this.selected.map(a => {
+        this.$store
+          .dispatch('alerts/takeAction', [
+            a.id,
+            'ack',
+            '',
+            this.ackTimeout
+          ])
+      })
         .reduce(() => this.clearSelected())
     },
     bulkShelveAlert() {

--- a/src/components/AlertDetail.vue
+++ b/src/components/AlertDetail.vue
@@ -75,7 +75,7 @@
             :disabled="!isOpen(item.status)"
             icon
             class="btn--plain px-1 mx-0"
-            @click="takeAction(item.id, 'ack')"
+            @click="ackAlert(item.id)"
           >
             <v-icon
               size="20px"
@@ -743,6 +743,7 @@
         :status="item.status"
         :is-watched="isWatched(item.tags)"
         @take-action="takeAction"
+        @ack-alert="ackAlert"
         @shelve-alert="shelveAlert"
         @watch-alert="watchAlert"
         @unwatch-alert="unwatchAlert"
@@ -817,6 +818,9 @@ export default {
         h => !h.hide || !this.$vuetify.breakpoint[h.hide]
       )
     },
+    ackTimeout() {
+      return this.$store.getters.getPreference('ackTimeout')
+    },
     shelveTimeout() {
       return this.$store.getters.getPreference('shelveTimeout')
     },
@@ -861,6 +865,11 @@ export default {
     takeAction: debounce(function(id, action, text) {
       this.$store
         .dispatch('alerts/takeAction', [id, action, text])
+        .then(() => this.getAlert(this.id))
+    }, 200, {leading: true, trailing: false}),
+    ackAlert: debounce(function(id, text) {
+      this.$store
+        .dispatch('alerts/takeAction', [id, 'ack', text, this.ackTimeout])
         .then(() => this.getAlert(this.id))
     }, 200, {leading: true, trailing: false}),
     shelveAlert: debounce(function(id, text) {

--- a/src/components/AlertListFilter.vue
+++ b/src/components/AlertListFilter.vue
@@ -324,9 +324,6 @@ export default {
     history() {
       return this.item.history.map((h, index) => ({ index: index, ...h }))
     },
-    shelveTimeout() {
-      return this.$store.getters.getPreference('shelveTimeout')
-    },
     isWatched() {
       const tag = `watch:${this.username}`
       return this.item.tags.indexOf(tag) > -1

--- a/src/components/Preferences.vue
+++ b/src/components/Preferences.vue
@@ -145,6 +145,14 @@
             />
 
             <v-combobox
+              v-model.number="ackTimeout"
+              :items="ackTimeoutOptions"
+              :label="$t('AckTimeout')"
+              type="number"
+              :suffix="$t('hours')"
+            />
+
+            <v-combobox
               v-model.number="shelveTimeout"
               :items="shelveTimeoutOptions"
               :label="$t('ShelveTimeout')"
@@ -210,6 +218,7 @@ export default {
       'HH:mm:ss.SSS Z',
     ],
     refreshOptions: [2, 5, 10, 30, 60],  // seconds
+    ackTimeoutOptions: [0, 1, 2, 4, 8, 24],  // hours
     shelveTimeoutOptions: [1, 2, 4, 8, 24]  // hours
   }),
   computed: {
@@ -337,6 +346,14 @@ export default {
       },
       set(value) {
         this.$store.dispatch('setUserPrefs', {refreshInterval: value * 1000})
+      }
+    },
+    ackTimeout: {
+      get() {
+        return this.$store.getters.getPreference('ackTimeout') / 60 / 60
+      },
+      set(value) {
+        this.$store.dispatch('setUserPrefs', {ackTimeout: value * 60 * 60})
       }
     },
     shelveTimeout: {

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -235,6 +235,7 @@ export const de = {
   rows: 'Zeilen',
   RefreshInterval: 'Aktualisierungsinterval',
   seconds: 'Sekunden',
+  AckTimeout: 'Ack timeout',
   ShelveTimeout: 'Shelve timeout',
   hours: 'Stunden',
 

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -235,6 +235,7 @@ export const en = {
   rows: 'rows',
   RefreshInterval: 'Refresh interval',
   seconds: 'seconds',
+  AckTimeout: 'Ack Timeout',
   ShelveTimeout: 'Shelve timeout',
   hours: 'hours',
 

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -234,6 +234,7 @@ export const fr = {
   rows: 'lignes',
   RefreshInterval: 'Intervalle de rafraîchissement',
   seconds: 'secondes',
+  AckTimeout: 'Durée de mise en affecter',
   ShelveTimeout: 'Durée de mise en attente',
   hours: 'heures',
 

--- a/src/store/modules/preferences.store.ts
+++ b/src/store/modules/preferences.store.ts
@@ -17,6 +17,7 @@ const getDefaults = () => {
     displayDensity: 'comfortable',  // 'comfortable' or 'compact'
     rowsPerPage: 20,
     refreshInterval: 5*1000,  // milliseconds
+    ackTimeout: 0,  // do not auto-unack, by default
     shelveTimeout: 2*60*60  // seconds
   }
 }


### PR DESCRIPTION
> this is something I never thought before neither but one colleague from support team told me that it is useful for them:
1) receive the notification of an alert
2) escalate it to proper team: mailing, ticket, ...
3) ack with a timeout, default timeout depending on the severity the incident
so an ack alert will be again visible for them after the timeout period to go again and chase proper team for resolution

See alerta/alerta#1187