### PR TITLE
Fix keycloak redirection after user logout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "dependencies": {
     "@alerta/vue-authenticate": {
-      "version": "github:alerta/vue-authenticate#0705c8f7a7c3b5dd3f4add2d5c803678fe57d1a8",
+      "version": "github:alerta/vue-authenticate#4454ebd2abcd89e13c2535af569dcf982321ce56",
       "from": "github:alerta/vue-authenticate",
       "requires": {
         "acorn": "^6.1.1",
@@ -17462,6 +17462,17 @@
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.11.tgz",
       "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ=="
+    },
+    "vue-authenticate": {
+      "version": "github:alerta/vue-authenticate#0705c8f7a7c3b5dd3f4add2d5c803678fe57d1a8",
+      "from": "github:alerta/vue-authenticate",
+      "requires": {
+        "acorn": "^6.1.1",
+        "ajv": "^6.10.0",
+        "axios": "^0.18.0",
+        "vue": "^2.6.10",
+        "vue-axios": "^2.1.4"
+      }
     },
     "vue-axios": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "moment": "^2.24.0",
     "typescript-eslint-parser": "^22.0.0",
     "vue": "^2.6.11",
+    "vue-authenticate": "github:alerta/vue-authenticate",
     "vue-class-component": "^6.0.0",
     "vue-i18n": "^8.15.4",
     "vue-object-merge": "^0.1.8",

--- a/src/components/ProfileMe.vue
+++ b/src/components/ProfileMe.vue
@@ -222,7 +222,12 @@ export default {
         .dispatch('auth/logout')
         .then(response => {
           if (response.data.logoutUrl) {
-            let redirectUrl = 'post_logout_redirect_url=' + window.location.origin + '/logout'
+            let redirectUrl =
+              (this.$config.provider == 'keycloak'
+                ? 'redirect_uri='
+                : 'post_logout_redirect_url=') +
+              window.location.origin +
+              '/logout'
             window.location.href = response.data.logoutUrl + '?' + redirectUrl
           } else {
             this.$router.push({ name: 'logout' })


### PR DESCRIPTION
The issue was two-fold. The "vue-authenticate" package the web UI was using didn't have the "return logout response" fix and the "redirect" param for keycloak is different to the OIDC specification. ie. it uses "redirect_uri" instead of "post_logout_redirect_url".

Fixes alerta/docker-alerta#172