### PR TITLE
Add primary UserID to Profile page and fix errors

### DIFF
--- a/src/components/auth/ProfileMe.vue
+++ b/src/components/auth/ProfileMe.vue
@@ -7,9 +7,11 @@
         <v-list-tile-content>
           <v-list-tile-title>{{ profile.name }}</v-list-tile-title>
           <v-list-tile-sub-title>
-            {{
-              profile.preferred_username
-            }}
+            <span>
+              <span
+                v-if="profile.preferred_username && !profile.preferred_username.includes('@')"
+              >@</span>{{ profile.preferred_username }}
+            </span>
           </v-list-tile-sub-title>
         </v-list-tile-content>
 

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -250,6 +250,7 @@ export const de = {
   // Profile
   Profile: 'Profil',
   UserID: 'User ID',
+  PrimaryUserID: 'Primäre User ID',
   Provider: 'Provider',
   EmailVerified: 'E-Mail verifiziert',
   EmailNotVerified: 'E-Mail nicht verifiziert',

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -250,6 +250,7 @@ export const en = {
   // Profile
   Profile: 'Profile',
   UserID: 'User ID',
+  PrimaryUserID: 'Primary User ID',
   Provider: 'Provider',
   EmailVerified: 'Email verified',
   EmailNotVerified: 'Email not verified',

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -249,6 +249,7 @@ export const fr = {
   // Profile
   Profile: 'Profil',
   UserID: 'User ID',
+  PrimaryUserID: 'Principal User ID',
   Provider: 'Provider',
   EmailVerified: 'Email verifié',
   EmailNotVerified: 'Email non verifié',

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -65,7 +65,10 @@
               layout
               text-xs-center
             >
-              <span v-if="!profile.preferred_username.includes('@')">@</span>{{ profile.preferred_username }}
+              <span
+                v-if="profile.preferred_username && !profile.preferred_username.includes('@')"
+              >@</span>
+              {{ profile.preferred_username }}
             </v-flex>
           </v-layout>
 
@@ -82,7 +85,7 @@
                   />
                 </v-flex>
                 <v-flex
-                  xs10
+                  xs9
                 >
                   <v-text-field
                     v-model="profile.preferred_username"
@@ -92,7 +95,8 @@
                 </v-flex>
 
                 <v-flex
-                  xs2
+                  xs3
+                  v-if="provider[profile.provider]"
                 >
                   <v-text-field
                     v-model="provider[profile.provider].text"
@@ -107,6 +111,17 @@
                   <v-text-field
                     v-model="profile.sub"
                     :label="$t('UserID')"
+                    readonly
+                  />
+                </v-flex>
+
+                <v-flex
+                  xs12
+                >
+                  <v-text-field
+                    v-if="profile.oid"
+                    v-model="profile.oid"
+                    :label="$t('PrimaryUserID')"
                     readonly
                   />
                 </v-flex>
@@ -140,6 +155,7 @@
                 </v-flex>
 
                 <v-flex
+                  v-if="$config.customer_views"
                   xs12
                 >
                   <v-combobox


### PR DESCRIPTION
Typical federated login JWT payload (note the `oid` which is the "Primary User ID") ...
```
{
  "iss": "http://api.local.alerta.io:8080/",
  "typ": "Bearer",
  "sub": "google-oauth2|104004764824066359390",
  "aud": "LMMEZSlPYKvM14cFxnWNWkC4DgvRk0dZ",
  "exp": 1606170378,
  "nbf": 1604960778,
  "iat": 1604960778,
  "jti": "ff3efae2-19b9-48c4-8811-b9b12897cc07",
  "name": "Nick Satterly",
  "preferred_username": "nfsatterly",
  "email": "xxx@gmail.com",
  "provider": "openid",
  "scope": "admin read write",
  "email_verified": true,
  "picture": "https://lh3.googleusercontent.com/a-/AOh14GhVkKzPmr4Fq8r4H7tty7Bsh9Uf6ZQWfqUxRS9YnQ=s96-c",
  "oid": "github|615057"
}
```
Fixes #376