### PR TITLE
Add line breaks to rawData

### DIFF
--- a/src/components/AlertDetail.vue
+++ b/src/components/AlertDetail.vue
@@ -1038,5 +1038,6 @@ export default {
 .console-text {
   font-size: 14px;
   font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  white-space: pre;
 }
 </style>


### PR DESCRIPTION
With 8.2.0 all the raw data is without any line breaks. Mind adding `white-space: pre` (or `white-space: pre-wrap` if you don't like the overflow in that area)? https://developer.mozilla.org/en-US/docs/Web/CSS/white-space