### PR TITLE
Allow usage of relative paths for base URLs to aid subpathed reverse proxies

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -1,7 +1,7 @@
 process.env.VUE_APP_VERSION = require('./package.json').version
 
 module.exports = {
-  publicPath: process.env.BASE_URL,
+  publicPath: '',
   chainWebpack: config => {
     config.module
       .rule('fonts')


### PR DESCRIPTION
In relation to alerta/docker-alerta#177, this patch allows hosting Alerta Web UI's SPA under a subpath behind reverse proxies.