### PR TITLE
fix: use notification for network error, not popup

### DIFF
--- a/src/services/api/interceptors.ts
+++ b/src/services/api/interceptors.ts
@@ -13,15 +13,7 @@ export function makeInterceptors(router) {
     // response handlers
     interceptErrors(error) {
       if (!error.response && !axios.isCancel(error)) {
-        alert(
-          'ERROR: A network error occurred. This could be a CORS issue or a ' +
-          'dropped internet connection.\n\n' +
-          'Check the browser javascript console and if the HTTP request has ' +
-          'been blocked by CORS then ensure that the "X-Request-ID" ' +
-          'header is in the "CORS_ALLOW_HEADERS" list in the Alerta API ' +
-          'configuration, or upgrade the Alerta API server to version 8.3.0 or ' +
-          'later.'
-        )
+        store.dispatch('notifications/error', Error('Problem connecting to Alerta API, retrying...'))
       }
 
       if (error.response) {


### PR DESCRIPTION
Replace this ...

<img width="448" alt="Screenshot 2021-04-18 at 17 50 42" src="https://user-images.githubusercontent.com/615057/115151768-a630e100-a06e-11eb-9811-030606eb012d.png">

... with this ...

<img width="540" alt="Screenshot 2021-04-18 at 17 49 51" src="https://user-images.githubusercontent.com/615057/115151773-aaf59500-a06e-11eb-8a6a-2b03be7dbe2e.png">

Fixes #461