### PR TITLE
feat: add preferences for blackout period start time and duration

### DIFF
--- a/src/components/BlackoutList.vue
+++ b/src/components/BlackoutList.vue
@@ -565,6 +565,15 @@ export default {
     formTitle() {
       return !this.editedId ? i18n.t('NewBlackout') : i18n.t('EditBlackout')
     },
+    blackoutStartNow() {
+      return this.$store.getters.getPreference('blackoutStartNow')
+    },
+    blackoutPeriod() {
+      return (
+        (this.$store.getters.getPreference('blackoutPeriod') ||
+          this.$store.getters.getConfig('blackouts').duration)
+      )
+    },
     times() {
       return Array.from(
         {
@@ -619,7 +628,11 @@ export default {
     getTags() {
       this.$store.dispatch('alerts/getTags')
     },
-    getNext15mins(date) {
+    getBlackoutTime(date) {
+      if (this.blackoutStartNow) {
+        return moment(date)
+      }
+      // return soonest 15 minute interval
       return moment(
         new Date(
           Math.ceil(date.getTime() / 1000 / 60 / 15) * 1000 * 60 * 15
@@ -628,9 +641,9 @@ export default {
     },
     defaultTimes() {
       let now = new Date()
-      let start = this.getNext15mins(now)
-      now.setTime(now.getTime() + 1 * 60 * 60 * 1000) // plus 1 hour
-      let end = this.getNext15mins(now)
+      let start = this.getBlackoutTime(now)
+      now.setTime(now.getTime() + this.blackoutPeriod * 1000)
+      let end = this.getBlackoutTime(now)
 
       return {
         startDate: start.format('YYYY-MM-DD'),

--- a/src/components/Preferences.vue
+++ b/src/components/Preferences.vue
@@ -229,6 +229,49 @@
       </v-flex>
     </v-card>
 
+    <v-card
+      flat
+      class="pl-3"
+    >
+      <v-flex
+        sm6
+        md4
+      >
+        <v-card-title
+          class="pb-0"
+        >
+          <div>
+            <div class="headline">
+              {{ $t('BlackoutSettings') }}
+            </div>
+          </div>
+        </v-card-title>
+        <v-card-actions>
+          <v-radio-group
+            class="mt-0"
+          >
+            <v-checkbox
+              v-model="blackoutStartNow"
+              :label="$t('BlackoutStartNow')"
+              hide-details
+              class="my-0"
+            />
+          </v-radio-group>
+        </v-card-actions>
+        <v-card-actions>
+          <v-layout column>
+            <v-combobox
+              v-model.number="blackoutPeriod"
+              :items="blackoutPeriodOptions"
+              :label="$t('BlackoutPeriod')"
+              type="number"
+              :suffix="$t('hours')"
+            />
+          </v-layout>
+        </v-card-actions>
+      </v-flex>
+    </v-card>
+
     <v-card flat>
       <v-flex
         sm6
@@ -298,6 +341,7 @@ export default {
     refreshOptions: [2, 5, 10, 30, 60],  // seconds
     ackTimeoutOptions: [0, 60, 120, 240, 480, 1440],  // minutes
     shelveTimeoutOptions: [60, 120, 240, 480, 1440],  // minutes
+    blackoutPeriodOptions: [1, 2, 8, 24, 48],  // hours
   }),
   computed: {
     languages() {
@@ -534,6 +578,25 @@ export default {
       },
       set(value) {
         this.$store.dispatch('setUserPrefs', {shelveTimeout: value * 60})
+      }
+    },
+    blackoutStartNow: {
+      get() {
+        return this.$store.getters.getPreference('blackoutStartNow')
+      },
+      set(value) {
+        this.$store.dispatch('toggle', ['blackoutStartNow', value])
+      }
+    },
+    blackoutPeriod: {
+      get() {
+        return (
+          (this.$store.getters.getPreference('blackoutPeriod') ||
+            this.$store.getters.getConfig('blackouts').duration) / 60 / 60
+        )
+      },
+      set(value) {
+        this.$store.dispatch('setUserPrefs', {blackoutPeriod: value * 60 * 60})
       }
     }
   },

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -256,6 +256,9 @@ export const de = {
   minutes: 'Minuten',
   AckTimeout: 'Ack timeout',
   ShelveTimeout: 'Shelve timeout',
+  BlackoutSettings: 'Blackoutseinstellungen',
+  BlackoutStartNow: 'Starten Sie den Zeitraum sofort',
+  BlackoutPeriod: 'Blackout Zeitraum',
   hours: 'Stunden',
 
   // Profile

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -256,6 +256,9 @@ export const en = {
   minutes: 'minutes',
   AckTimeout: 'Ack Timeout',
   ShelveTimeout: 'Shelve timeout',
+  BlackoutSettings: 'Blackout period settings',
+  BlackoutStartNow: 'Start blackout periods immediately',
+  BlackoutPeriod: 'Blackout Period',
   hours: 'hours',
 
   // Profile

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -256,6 +256,9 @@ export const fr = {
   minutes: 'minutes',
   AckTimeout: 'Durée de mise en affecter',
   ShelveTimeout: 'Durée de mise en attente',
+  BlackoutSettings: 'Paramètres de blackout',
+  BlackoutStartNow: 'Commencer immédiatement la période d\'incident',
+  BlackoutPeriod: 'Durée de la période d\'incident',
   hours: 'heures',
 
   // Profile

--- a/src/store/modules/config.store.ts
+++ b/src/store/modules/config.store.ts
@@ -26,6 +26,8 @@ const state = {
 
   timeouts: {}, // includes alert, heartbeat, ack and shelve timeouts
 
+  blackouts: {}, // include default duration
+
   dates: {
     longDate: 'ddd D MMM, YYYY HH:mm:ss.SSS Z',
     mediumDate: 'ddd D MMM HH:mm',

--- a/src/store/modules/preferences.store.ts
+++ b/src/store/modules/preferences.store.ts
@@ -28,6 +28,8 @@ const getDefaults = () => {
     refreshInterval: 5*1000,  // milliseconds
     ackTimeout: null,
     shelveTimeout: null,
+    blackoutStartNow: true,
+    blackoutPeriod: null,
     queries: []
   }
 }


### PR DESCRIPTION

Alerta API setting ...
```
# blackout settings
BLACKOUT_DURATION = 3600  # default period = 1 hour
```

Web UI preferences...

<img width="407" alt="Screenshot 2021-04-25 at 12 25 05" src="https://user-images.githubusercontent.com/615057/115989995-4d5ace80-a5c1-11eb-9c38-0fc276549714.png">

Fixes #449