### PR TITLE
Do not reset stored user preferences on logout

### DIFF
--- a/src/components/auth/ProfileMe.vue
+++ b/src/components/auth/ProfileMe.vue
@@ -223,7 +223,7 @@ export default {
   },
   methods: {
     logout() {
-      this.$store.dispatch('resetUserPrefs')
+      this.$store.dispatch('clearUserPrefs')
       this.$store
         .dispatch('auth/logout')
         .then(response => {

--- a/src/store/modules/preferences.store.ts
+++ b/src/store/modules/preferences.store.ts
@@ -92,6 +92,9 @@ const actions = {
         })
       )
   },
+  clearUserPrefs({commit}) {
+    commit('RESET_PREFS')
+  },
   getUserQueries({dispatch, commit}) {
     return UsersApi.getMeAttributes()
       .then(({attributes}) => {


### PR DESCRIPTION
User preferences are now persisted between user sessions...

```json
{
    "prefs": {
        "font": {
            "font-family": "\"Helvetica\", Arial, sans-serif"
        },
        "isDark": true,
        "timezone": "utc",
        "textWidth": 404,
        "languagePref": "de",
        "showNotesIcon": true,
        "blackoutPeriod": 7200
    }
}
```

Fixes #453