### PR TITLE
Treat ISA 18.2 UNACK and RTNUN as Open

### DIFF
--- a/src/components/AlertActions.vue
+++ b/src/components/AlertActions.vue
@@ -193,7 +193,7 @@ export default {
       return this.$store.getters.getPreference('isDark')
     },
     isOpen(status) {
-      return this.status == 'open' || this.status == 'NORM'
+      return this.status == 'open' || this.status == 'NORM' || this.status == 'UNACK' || this.status == 'RTNUN'
     },
     isAcked() {
       return this.status == 'ack' || this.status == 'ACKED'

--- a/src/components/AlertDetail.vue
+++ b/src/components/AlertDetail.vue
@@ -962,7 +962,7 @@ export default {
       this.$store.dispatch('alerts/getNotes', this.id)
     },
     isOpen(status) {
-      return status == 'open' || status == 'NORM'
+      return status == 'open' || status == 'NORM' || status == 'UNACK' || status == 'RTNUN'
     },
     isWatched(tags) {
       const tag = `watch:${this.username}`

--- a/src/components/AlertList.vue
+++ b/src/components/AlertList.vue
@@ -646,7 +646,7 @@ export default {
       }
     },
     isOpen(status) {
-      return status == 'open' || status == 'NORM'
+      return status == 'open' || status == 'NORM' || status == 'UNACK' || status == 'RTNUN'
     },
     isWatched(tags) {
       return tags ? tags.indexOf(`watch:${this.username}`) > -1 : false


### PR DESCRIPTION
The web UI currently does not recognise the UNACK and RTNUN states, and thus does not allow any action once an alert occurs with a severity beyond Normal (which would get the NORM state). Since both states represent an unacknowledged alert, it seems appropriate to make them effectively equal to the Open state for the sake of the UI.