### PR TITLE
render HTML marked-up attributes

### DIFF
--- a/src/components/AlertDetail.vue
+++ b/src/components/AlertDetail.vue
@@ -725,7 +725,7 @@
                         </span>
                       </div>
                       <div
-                        v-else-if="typeof value === 'string' && (value.includes('http://') || value.includes('https://'))"
+                        v-else-if="typeof value === 'string' && /<\/?[a-z][\s\S]*>/i.test(value)"
                         class="link-text"
                         v-html="value"
                       />


### PR DESCRIPTION
This addresses #535. Rather than rendering attributes if they contain a link, look for things that look like HTML tags instead.

I considered the code-injection potential of this, but I don't think it's any better or worse than the current code, as anything with `http://` in it would be rendered currently.