### PR TITLE
fix: revert back to upstream for vue-authenticate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "8.7.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@alerta/vue-authenticate": "github:alerta/vue-authenticate",
         "acorn-dynamic-import": "^4.0.0",
         "axios": "^0.21.2",
         "export-to-csv": "^0.2.1",
@@ -17,7 +16,7 @@
         "moment": "^2.29.1",
         "typescript-eslint-parser": "^22.0.0",
         "vue": "^2.6.14",
-        "vue-authenticate": "github:alerta/vue-authenticate",
+        "vue-authenticate": "1.5.0",
         "vue-class-component": "^6.0.0",
         "vue-i18n": "^8.26.7",
         "vue-object-merge": "^0.1.8",
@@ -65,23 +64,6 @@
       },
       "engines": {
         "node": "8 || 10 || 12 || 14 || 16 || 17"
-      }
-    },
-    "node_modules/@alerta/vue-authenticate": {
-      "version": "1.5.0",
-      "resolved": "git+ssh://git@github.com/alerta/vue-authenticate.git#ff6de656aa1929f242d8fa3ab4afae72c808fffa",
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^6.1.1",
-        "ajv": "^8.1.0",
-        "axios": "^0.21.1",
-        "vue": "^2.6.10",
-        "vue-axios": "^2.1.4"
-      },
-      "peerDependencies": {
-        "acorn": "^6.0.0",
-        "acorn-dynamic-import": "^4.0.0",
-        "ajv": "^6.9.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -30843,17 +30825,6 @@
         "js-message": "1.0.7"
       }
     },
-    "@alerta/vue-authenticate": {
-      "version": "git+ssh://git@github.com/alerta/vue-authenticate.git#ff6de656aa1929f242d8fa3ab4afae72c808fffa",
-      "from": "@alerta/vue-authenticate@github:alerta/vue-authenticate",
-      "requires": {
-        "acorn": "^6.1.1",
-        "ajv": "^8.1.0",
-        "axios": "^0.21.1",
-        "vue": "^2.6.10",
-        "vue-axios": "^2.1.4"
-      }
-    },
     "@ampproject/remapping": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -54032,7 +54003,7 @@
     },
     "vue-authenticate": {
       "version": "git+ssh://git@github.com/alerta/vue-authenticate.git#ff6de656aa1929f242d8fa3ab4afae72c808fffa",
-      "from": "vue-authenticate@github:alerta/vue-authenticate",
+      "from": "vue-authenticate@1.5.0",
       "requires": {
         "acorn": "^6.1.1",
         "ajv": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "author": "satterly",
   "license": "Apache-2.0",
   "dependencies": {
-    "@alerta/vue-authenticate": "github:alerta/vue-authenticate",
     "acorn-dynamic-import": "^4.0.0",
     "axios": "^0.21.2",
     "export-to-csv": "^0.2.1",
@@ -34,7 +33,7 @@
     "moment": "^2.29.1",
     "typescript-eslint-parser": "^22.0.0",
     "vue": "^2.6.14",
-    "vue-authenticate": "github:alerta/vue-authenticate",
+    "vue-authenticate": "1.5.0",
     "vue-class-component": "^6.0.0",
     "vue-i18n": "^8.26.7",
     "vue-object-merge": "^0.1.8",

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
 import VueAxios from 'vue-axios'
-import {VueAuthenticate} from '@alerta/vue-authenticate'
+import {VueAuthenticate} from 'vue-authenticate'
 import axios from 'axios'
 
 Vue.use(Vuex)


### PR DESCRIPTION
**Description**
The upstream `vue-authenticate` package has included the fix needed for logout redirection so maintaining our own version is no longer necessary.

Fixes #531

**Changes**
Switch back to `vue-authenticate`.

**Checklist**
- [x] Pull request is limited to a single purpose
- [x] Code style/formatting is consistent
- [x] All existing tests are passing
- [x] Added new tests related to change
- [x] No unnecessary whitespace changes
