### PR TITLE
allow applying a note to multiple alerts at once

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -314,6 +314,19 @@
             slot="activator"
             icon
             class="btn--plain"
+            @click="showAddNoteForm = !showAddNoteForm"
+          >
+            <v-icon>
+              notes
+            </v-icon>
+          </v-btn>
+          <span>{{ $t('Notes') }}</span>
+        </v-tooltip>
+        <v-tooltip bottom>
+          <v-btn
+            slot="activator"
+            icon
+            class="btn--plain"
             @click="bulkShelveAlert()"
           >
             <v-icon>
@@ -462,6 +475,31 @@
           </v-btn>
         </span>
       </v-toolbar>
+      <v-container
+        v-if="showAddNoteForm"
+        class="pa-1"
+        fluid
+      >
+        <v-layout>
+          <v-flex>
+            <v-card>
+              <v-card-text>
+                <v-text-field
+                  v-model.trim="text"
+                  :counter="maxNoteLength"
+                  :maxlength="maxNoteLength"
+                  :minlength="minNoteLength"
+                  :rules="textRules"
+                  :label="$t('AddNote')"
+                  prepend-icon="edit"
+                  required
+                  @keydown.enter="bulkAddNotes()"
+                />
+              </v-card-text>
+            </v-card>
+          </v-flex>
+        </v-layout>
+      </v-container>
     </div>
 
     <v-content>
@@ -513,7 +551,16 @@ export default {
     Snackbar
   },
   props: [],
-  data: () => ({
+  data: vm => ({
+    showAddNoteForm: false,
+    text: '',
+    valid: true,
+    maxNoteLength: 200,
+    minNoteLength: 0,
+    textRules: [
+      v => !!v || i18n.t('TextIsRequired'),
+      v => (v && v.length <= vm.maxNoteLength) || `${i18n.t('TextMustBeLessThan')} ${vm.maxNoteLength} ${i18n.t('characters')}`
+    ],
     hasFocus: false,
     menu: false,
     message: false,
@@ -763,6 +810,13 @@ export default {
           ])
       })
         .reduce(() => this.clearSelected())
+    },
+    bulkAddNotes() {
+      Promise.all(this.selected.map(a => this.$store.dispatch('alerts/addNote', [a.id, this.text]))).then(() => {
+        this.showAddNoteForm = false
+        this.clearSelected()
+        this.text=''
+      })
     },
     bulkShelveAlert() {
       Promise.all(this.selected.map(a => {

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -70,6 +70,7 @@ export const de = {
   Unshelve: 'Unshelve',
   Close: 'Schließen',
   Watch: 'Beobachten',
+  Notes: 'Notities',
   Unwatch: 'Nicht beobachten',
   AddNote: 'Notiz hinzufügen',
   Delete: 'Löschen',

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -70,6 +70,7 @@ export const en = {
   Unshelve: 'Unshelve',
   Close: 'Close',
   Watch: 'Watch',
+  Notes: 'Notes',
   Unwatch: 'Unwatch',
   AddNote: 'Add note',
   Delete: 'Delete',

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -70,6 +70,7 @@ export const fr = {
   Unshelve: 'Unshelve',
   Close: 'Close', //'Fermé',
   Watch: 'Watch', //'Surveiller',
+  Notes: 'Notes', // 'Remarques'
   Unwatch: 'Unwatch', //'Ne plus surveiller',
   AddNote: 'Add note', //'Ajouter Note',
   Delete: 'Delete', //'Supprimer',

--- a/src/locales/tr.js
+++ b/src/locales/tr.js
@@ -70,6 +70,7 @@ export const tr = {
   Unshelve: 'Raftan kaldır',
   Close: 'Kapat',
   Watch: 'İzle',
+  Notes: 'Notlar',
   Unwatch: 'İzleme kaldır',
   AddNote: 'Not ekle',
   Delete: 'Sil',


### PR DESCRIPTION
**Description**
Allows applying a note to multiple alerts at once

**Changes**
Adds a new notes icon in the toolbar header for applying notes to multiple selected notes
 
**Screenshots**
If it's a UI change add screenshots to demonstrate changes.

https://user-images.githubusercontent.com/3026841/224114411-599fb892-6fca-410f-9f30-61a35ef3b9cb.mov

**Checklist**
- [x] Pull request is limited to a single purpose
- [x] Code style/formatting is consistent
- [] All existing tests are passing
- [] Added new tests related to change
- [x] No unnecessary whitespace changes

**Collaboration**
When a user creates a pull request from a fork that they own, the user
generally has the authority to decide if other users can commit to the
pull request's compare branch. If the pull request author wants greater
collaboration, they can grant maintainers of the upstream repository
(that is, anyone with push access to the upstream repository) permission
to commit to the pull request's compare branch

See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork

