### PR TITLE
Replace deprecated upload release asset action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,24 +62,16 @@ jobs:
           prerelease: false
       - name: Upload Zip File
         id: upload-zip-file
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }} 
-          asset_path: ./alerta-webui.zip
-          asset_name: alerta-webui.zip
-          asset_content_type: application/zip
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: ./alerta-webui.zip
       - name: Upload Compressed TAR File
         id: upload-tarball
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }} 
-          asset_path: ./alerta-webui.tar.gz
-          asset_name: alerta-webui.tar.gz
-          asset_content_type: application/gzip
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: ./alerta-webui.tar.gz
 
       - uses: act10ns/slack@v2
         with:


### PR DESCRIPTION
**Description**
A clear and concise description of **why** this change is necessary.

Fixes # (issue)

**Changes**
Include a brief summary of changes...
- change 1
- change 2
- change 3

**Screenshots**
If it's a UI change add screenshots to demonstrate changes.

**Checklist**
- [ ] Pull request is limited to a single purpose
- [ ] Code style/formatting is consistent
- [ ] All existing tests are passing
- [ ] Added new tests related to change
- [ ] No unnecessary whitespace changes

**Collaboration**
When a user creates a pull request from a fork that they own, the user
generally has the authority to decide if other users can commit to the
pull request's compare branch. If the pull request author wants greater
collaboration, they can grant maintainers of the upstream repository
(that is, anyone with push access to the upstream repository) permission
to commit to the pull request's compare branch

See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork

