### PR TITLE
fix: Keycloak url base

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -82,7 +82,7 @@ export function vueAuth(config) {
         name: 'Keycloak',
         url: '/auth/keycloak',
         clientId: config.client_id,
-        authorizationEndpoint: `${config.keycloak_url}/auth/realms/${config.keycloak_realm}/protocol/openid-connect/auth`,
+        authorizationEndpoint: `${config.keycloak_url}/realms/${config.keycloak_realm}/protocol/openid-connect/auth`,
         redirectUri: getRedirectUri(basePath),
         requiredUrlParams: ['scope'],
         optionalUrlParams: ['display', 'state'],


### PR DESCRIPTION
**Description**
OIDC integration with Keycloak does not work unless Keycloak is configured with /auth in the context path.

Fix Keycloak url conforming to: https://github.com/alerta/alerta/pull/1683
Fixes https://github.com/alerta/alerta-webui/issues/570

**Changes**
- Remove `/auth` from Keycloak url.

**Checklist**
- [ ] Pull request is limited to a single purpose
- [ ] Code style/formatting is consistent
- [ ] All existing tests are passing
- [ ] Added new tests related to change
- [ ] No unnecessary whitespace changes

**Collaboration**
When a user creates a pull request from a fork that they own, the user
generally has the authority to decide if other users can commit to the
pull request's compare branch. If the pull request author wants greater
collaboration, they can grant maintainers of the upstream repository
(that is, anyone with push access to the upstream repository) permission
to commit to the pull request's compare branch

See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork

